### PR TITLE
Encode image file path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -304,6 +304,7 @@ class Paster {
         }
 
         imageFilePath = `${prefix}${imageFilePath}${suffix}`;
+        imageFilePath = encodeURI(imageFilePath);
 
         switch (languageId) {
             case "markdown":


### PR DESCRIPTION
If there are special characters like spaces in the image file, the image
won't show correctly.

Fix it by encoding the image path in the markdown or asciidoc file.