### PR TITLE
Add MDX support

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -389,6 +389,10 @@ class Paster {
         let imageSyntaxPrefix = "";
         let imageSyntaxSuffix = ""
         switch (languageId) {
+            case "mdx":
+                imageSyntaxPrefix = `![](`
+                imageSyntaxSuffix = `)`
+                break;
             case "markdown":
                 imageSyntaxPrefix = `![](`
                 imageSyntaxSuffix = `)`


### PR DESCRIPTION
Adds MDX support.

MDX allows for JSX to be added into Markdown - I thought it would be great if this extension would allow that as well :smile: 

The syntax is the same as Markdown, the only thing that needs to be added is an extra switch case.

