### PR TITLE
Select only the filename part when asking for the filePath

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -215,11 +215,14 @@ class Paster {
         } else {
             filePathOrName = imageFileName;
         }
+        let selectionRange = [filePathOrName.length - imageFileName.length,
+                              filePathOrName.length - ".png".length];
 
         if (showFilePathConfirmInputBox) {
             vscode.window.showInputBox({
                 prompt: 'Please specify the filename of the image.',
-                value: filePathOrName
+                value: filePathOrName,
+                valueSelection: selectionRange
             }).then((result) => {
                 if (result) {
                     if (!result.endsWith('.png')) result += '.png';


### PR DESCRIPTION
When I paste images, I seldom write the whole path. Instead, I only change the filename of the saved image. So, it could be convenient if only the filename part is selected by default when the input box appears.

How do you like it?

Here is the screenshot:
![image](https://user-images.githubusercontent.com/10482293/89790482-9282c180-db54-11ea-9bd4-0ec9417b88e8.png)
