### PR TITLE
added functionality that allows new line variable

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,6 +58,7 @@ class Paster {
     static PATH_VARIABLE_IMAGE_ORIGINAL_FILE_PATH = /\$\{imageOriginalFilePath\}/g;
     static PATH_VARIABLE_IMAGE_FILE_NAME = /\$\{imageFileName\}/g;
     static PATH_VARIABLE_IMAGE_FILE_NAME_WITHOUT_EXT = /\$\{imageFileNameWithoutExt\}/g;
+    static NEW_LINE_PLACEHOLDER_TEXT = /\$\{newLine}/g
     static PATH_VARIABLE_IMAGE_SYNTAX_PREFIX = /\$\{imageSyntaxPrefix\}/g;
     static PATH_VARIABLE_IMAGE_SYNTAX_SUFFIX = /\$\{imageSyntaxSuffix\}/g;
 
@@ -407,6 +408,7 @@ class Paster {
         result = result.replace(this.PATH_VARIABLE_IMAGE_ORIGINAL_FILE_PATH, originalImagePath);
         result = result.replace(this.PATH_VARIABLE_IMAGE_FILE_NAME, fileName);
         result = result.replace(this.PATH_VARIABLE_IMAGE_FILE_NAME_WITHOUT_EXT, fileNameWithoutExt);
+        result = result.replace(this.NEW_LINE_PLACEHOLDER_TEXT, "\n");
 
         return result;
     }


### PR DESCRIPTION
as stated in issue #58, if new-line support would be added to this extention, it would allow increadibly better and more suffisticated suffixes and prefixes in pastes.
please add this in, for it would easily extend the usecase of this great extention a lot more.

for example:
I allways want my images to be inside centered tables, with a place for an image description, like so

```
|  |
|:---:|
|![lsome_image.png]|
|- image description -|
```

which looks something like this:
|  |
|:---:|
|![lsome_image.png]|
|- image description -|

and of course an other example is the one stated in #58