### PR TITLE
fix: allow image path encoding to extend to the image filename too

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -382,8 +382,10 @@ class Paster {
 
         if (this.encodePathConfig == "urlEncode") {
             imageFilePath = encodeURI(imageFilePath)
+            fileName = encodeURI(fileName)
         } else if (this.encodePathConfig == "urlEncodeSpace") {
             imageFilePath = imageFilePath.replace(/ /g, "%20");
+            fileName = fileName.replace(/ /g, "%20");
         }
 
         let imageSyntaxPrefix = "";


### PR DESCRIPTION
Fixes #117 

Allows encoding to apply to the file name too, in case that has spaces or other characters that need to be encoded.